### PR TITLE
Encode texture metadata

### DIFF
--- a/src/common/dag.h
+++ b/src/common/dag.h
@@ -78,18 +78,36 @@ struct Patch {
 	uint32_t texture;          //index of the texture in the array of textures
 };
 
+
+#define TEXURE_MAGIC_CODE 0x7F800001
+
 struct Texture {
 	uint32_t offset;
-	float matrix[16];
-	Texture(): offset(-1) {
-		for(int i = 0; i < 16; i++)
-			matrix[i] = 0;
+	//This texture meta data replaces an unused 4x4 transform matrix
+	uint32_t width;
+	uint32_t height;
+	uint32_t magic; //Magic indentifies this as image metadata, not transform matrix
+
+	uint32_t byteLength[2]; //Encode 64-bit bytelength as two 32-bit number to avoid packing problems
+	uint32_t padding[11];
+
+	Texture(): 
+		offset(-1),
+		magic(TEXURE_MAGIC_CODE),
+		width(0),
+		height(0)  
+	{
+		byteLength[0] = 0;
+		byteLength[1] = 0;
 	}
 
 	uint64_t getBeginOffset() { return (uint64_t)offset * (uint64_t) NEXUS_PADDING; }
 	uint64_t getEndOffset() { return (this+1)->getBeginOffset(); }
 	uint64_t getSize() { return getEndOffset() - getBeginOffset(); }
 };
+
+static_assert( sizeof(Texture)==68, "Invalid texture size" );
+
 
 }//
 #endif // NX_DAG_H

--- a/src/nxsbuild/nexusbuilder.cpp
+++ b/src/nxsbuild/nexusbuilder.cpp
@@ -674,6 +674,13 @@ void NexusBuilder::createLevel(KDTree *in, Stream *out, int level) {
 					output_pixels += nodetex.width()*nodetex.height();
 					Texture t;
 					t.offset = nodeTex.size()/NEXUS_PADDING;
+					t.width =  nodetex.width();
+					t.height = nodetex.height();
+
+					//Pack into uint32 array
+					uint64_t* byteLength = (uint64_t*)&t.byteLength[0];
+					*byteLength = nodetex.width()*nodetex.height()*4;
+
 					textures.push_back(t);
 
 					QImageWriter writer(&nodeTex, "jpg");


### PR DESCRIPTION
In order to properly control the memory footprint on the client, we need to know the exact texture size.  The 10x estimate we are using at the moment will lead to objects being unloaded unnecessarily (particular now I'm hooking up the asset cache to nexus, so GLTFs will get unloaded if nexus cach estimate is too high).  As the textures are JPGs my plan A of peeking at the texture buffer to work out size on the client doesn't work (as the size is not stored at the start of the JPG :( )

Fortunately there is 4x4 float transform matrix in the Texture structure that is not used either in the builder or client (it's just unused bits, and anyway does not need be 4x4 floats for a texture transform unless I'm missing the intention).  So I've replaced that with width, height, byteLength and "magic" field.  The magic code ensures backwards compatibility, so we only read the texture metadata if that is set (I use NaN value as the magic number), otherwise we fall back to the 10x estimate.  The matrix is skipped on the old nexus.js client so new files will backwards compatible.


